### PR TITLE
De 621: Add confirmation page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -27,6 +27,11 @@ const router = createRouter({
       name: "PractitionerInfo",
       component: () => import("../views/PractitionerInfo.vue"),
     },
+    {
+      path: "/submission-page",
+      name: "SubmissionPage",
+      component: () => import("../views/SubmissionPage.vue"),
+    },
   ],
 });
 

--- a/src/views/SubmissionPage.vue
+++ b/src/views/SubmissionPage.vue
@@ -3,7 +3,7 @@
     <PageContent>
       <main class="container pt-3 pt-sm-5 mb-5">
         <h1>Confirmation of submission</h1>
-        <p>Date submitted: {insert date here}</p>
+        <p>Date submitted: {insert date here} {insert print page button here}</p>
         <!-- make date submitted bold-->
 
         <h2>Next steps</h2>
@@ -36,7 +36,7 @@
         <CheckboxComponent
           id="patient-name"
           v-model="patientName"
-          :label="'insert firstname/lastname here'"
+          :label="'{insert firstname/lastname here}'"
           :disabled="true"
           @blur="handleBlurField(v$.isAuthorizedFPCAH)"
         />

--- a/src/views/SubmissionPage.vue
+++ b/src/views/SubmissionPage.vue
@@ -1,0 +1,83 @@
+<template>
+  <main>
+    <PageContent>
+      <main class="container pt-3 pt-sm-5 mb-5">
+        <h1>Confirmation of submission</h1>
+        <p>Date submitted: {insert date here}</p>
+        <!-- make date submitted bold-->
+
+        <h2>Next steps</h2>
+        <hr />
+        <p>Print or save this page for your records.</p>
+        <!-- make print or save sentence bold-->
+        <p>
+          Your documents will be added to your claim/pre-authorization file so the adjudicator can
+          complete the request and continue processing. Please allow two to three weeks for your
+          request to be completed.
+        </p>
+        <h2>Claim / Pre-authorization information</h2>
+        <hr />
+        (insert tables here)
+        <h2>Declaration of accuracy and validity</h2>
+        <hr />
+        <p>
+          I hereby declare that the information provided through this web form is accurate,
+          complete, and truthful to the best of my knowledge. I confirm that all information
+          provided pertains to a single patient and is valid for a single claim or
+          pre-authorization. I understand that any false, misleading, or omitted information may
+          result in the rejection of my submission and could have legal consequences.
+        </p>
+        <p>
+          By submitting this form, I affirm that I have personally completed all sections and that
+          the information I have provided is a true and honest representation of the facts. I
+          acknowledge that it is my responsibility to update any changes to this information
+          promptly.
+        </p>
+        <CheckboxComponent
+          id="patient-name"
+          v-model="patientName"
+          :label="'insert firstname/lastname here'"
+          :disabled="true"
+          @blur="handleBlurField(v$.isAuthorizedFPCAH)"
+        />
+      </main>
+    </PageContent>
+  </main>
+</template>
+
+<script setup>
+// import { useFormStore } from "@/stores/formData";
+import { PageContent, CheckboxComponent } from "common-lib-vue";
+// const store = useFormStore();
+// import { smallStyles, mediumStyles } from "@/constants/input-styles";
+</script>
+
+<script>
+export default {
+  data() {
+    return {
+      documentsCategory: null,
+      patientName: null,
+    };
+  },
+
+  computed: {
+    radioOptionsDocumentsCategory() {
+      return [
+        {
+          id: "documents-category-claim",
+          label: "Documents are for a claim",
+          value: "claim",
+        },
+        {
+          id: "documents-category-pre-auth",
+          label: "Documents are for a pre-authorization",
+          value: "pre-auth",
+        },
+      ];
+    },
+  },
+
+  methods: {},
+};
+</script>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [ ] After these changes, the app was run and still works as expected
- [ ] Tests for these changes were added (if applicable)
- [ ] `npm audit` was checked, applicable vulnerabilities were updated
- [x] `npm run build` passes
- [x] `npm run lint` has no unexpected errors
- [x] `npm run format` has no unexpected errors
- [x] All existing unit tests were run and still pass (`npm run test:unit`)
- [ ] End-to-end tests were run and still pass in Chrome, Firefox, and Edge without unexpected console errors (`npm run test:e2e`)

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Adds skeleton for a submission page (checkbox in declaration is present working, review table and print page button are not present)

### Additional Notes:
You can view the page through the /ccup/submission-page route in your local environment